### PR TITLE
uses last-played song instead of "now playing" song

### DIFF
--- a/nowplaying.py
+++ b/nowplaying.py
@@ -32,7 +32,7 @@ class NowplayingBot(PineappleBot):
     @interval(30)
     def post_np(self):
         # grab the track from the last.fm api
-        currently_playing = self.lastfm.get_user(self.config.lastfm_username).get_now_playing()
+        currently_playing = self.lastfm.get_user(self.config.lastfm_username).get_recent_tracks(1)[0][0]
 
         # don't try to post if nothing is being played
         if currently_playing is None:


### PR DESCRIPTION
downside: will (re)post the last song you listened to on startup
upside: works with scrobblers that don't set the now-playing value correctly (which seems to include manual web scrobblers)

makes a 'last played' request of length 1, gets the first (and only) item and extracts the track object from that played_track object